### PR TITLE
Fix "OpenFile" hidden dialog

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -209,7 +209,7 @@ void MainWindow::ResetView()
 
 void MainWindow::OpenVideoFile()
 {
-	QString file = QFileDialog::getOpenFileName(this, tr("Open Video"));
+        QString file = QFileDialog::getOpenFileName(this, tr("Open Video"), QDir::currentPath(), tr("All files (*)"), Q_NULLPTR, QFileFialog::DontUseNativeDialog);
 
 	if(file.isNull())
 		return;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -209,7 +209,7 @@ void MainWindow::ResetView()
 
 void MainWindow::OpenVideoFile()
 {
-        QString file = QFileDialog::getOpenFileName(this, tr("Open Video"), QDir::currentPath(), tr("All files (*)"), Q_NULLPTR, QFileFialog::DontUseNativeDialog);
+	QString file = QFileDialog::getOpenFileName(this, tr("Open Video"), QDir::currentPath(), tr("All files (*)"), Q_NULLPTR, QFileFialog::DontUseNativeDialog);
 
 	if(file.isNull())
 		return;


### PR DESCRIPTION
Hi,

I'm using Debian Unstable with Qt4.8. The "OpenFile" dialog is not showed with the current code, the windows list show the dialog title, but the widget is not showed. With this little fix the dialog it's showed.

Thanks for your app!
